### PR TITLE
New Toolkit version 2.3

### DIFF
--- a/artifacts/install-toolkit.sh
+++ b/artifacts/install-toolkit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 APP_PATH=/app
-TOOLKIT_URL=http://www.combodo.com/documentation/iTopDataModelToolkit-2.2.zip
+TOOLKIT_URL=http://www.combodo.com/documentation/iTopDataModelToolkit-2.3.zip
 TOOLKIT_FOLDER=$APP_PATH/toolkit
 
 if [[ -d $APP_PATH ]]; then


### PR DESCRIPTION
As seen in the  [2.3 documentation](https://wiki.openitop.org/doku.php?id=2_3_0:customization:datamodel), the Toolkit as a new version available.