### PR TITLE
Allow to build without MySQL Database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Vladimir Kunin <vladimir@knowitop.ru>
 
 ARG DEBIAN_FRONTEND=noninteractive
 # Provide Build-Argument to skip MySQL installation
-# Use with '--build-args NO_DATABASE true' during docker build
+# Use with '--build-arg NO_DATABASE=true' during docker build
 ARG NO_DATABASE=false
 ENV no_database=$NO_DATABASE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM phusion/baseimage
 MAINTAINER Vladimir Kunin <vladimir@knowitop.ru>
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Provide Build-Argument to skip MySQL installation
+# Use with '--build-args NO_DATABASE true' during docker build
 ARG NO_DATABASE=false
 ENV no_database=$NO_DATABASE
 
@@ -15,7 +17,7 @@ RUN apt-get install -y \
     graphviz curl \
     git wget unzip
 
-RUN if [ $NO_DATABASE == false ] ; then apt-get install -y mariadb-server pwgen ; fi
+RUN if [ "$NO_DATABASE" = false ]; then apt-get install -y mariadb-server pwgen ; fi
 # Remove pre-installed database and apache demo data
 RUN rm -rf /var/lib/mysql/* /var/www/html/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM phusion/baseimage
 MAINTAINER Vladimir Kunin <vladimir@knowitop.ru>
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NO_DATABASE=false
 
 RUN apt-get install -y software-properties-common \
  && add-apt-repository -y ppa:ondrej/php \
@@ -10,10 +11,10 @@ RUN apt-get install -y software-properties-common \
 RUN apt-get install -y \
     apache2 \
     php7.1 php7.1-xml php7.1-mysql php7.1-json php7.1-mcrypt php7.1-mbstring php7.1-ldap php7.1-soap php7.1-zip php7.1-gd \
-    graphviz \
+    graphviz curl \
     git wget unzip
 
-RUN apt-get install -y mariadb-server pwgen
+RUN if [ "x$NO_DATABASE" = "true" ] ; then apt-get install -y mariadb-server pwgen ; fi
 # Remove pre-installed database and apache demo data
 RUN rm -rf /var/lib/mysql/* /var/www/html/*
 
@@ -53,6 +54,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 VOLUME /var/lib/mysql
 
-EXPOSE 80 3306
+EXPOSE 80
+HEALTHCHECK --interval=5m --timeout=3s CMD curl -f http://localhost/ || exit 1
 
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y \
     graphviz curl \
     git wget unzip
 
-RUN if [ "x$NO_DATABASE" = "true" ] ; then apt-get install -y mariadb-server pwgen ; fi
+RUN if [ "x$NO_DATABASE" == false ] ; then apt-get install -y mariadb-server pwgen ; fi
 # Remove pre-installed database and apache demo data
 RUN rm -rf /var/lib/mysql/* /var/www/html/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y \
     graphviz curl \
     git wget unzip
 
-RUN if [ "x$NO_DATABASE" == false ] ; then apt-get install -y mariadb-server pwgen ; fi
+RUN if [ $NO_DATABASE == false ] ; then apt-get install -y mariadb-server pwgen ; fi
 # Remove pre-installed database and apache demo data
 RUN rm -rf /var/lib/mysql/* /var/www/html/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Vladimir Kunin <vladimir@knowitop.ru>
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NO_DATABASE=false
+ENV no_database=$NO_DATABASE
 
 RUN apt-get install -y software-properties-common \
  && add-apt-repository -y ppa:ondrej/php \
@@ -57,4 +58,4 @@ VOLUME /var/lib/mysql
 EXPOSE 80
 HEALTHCHECK --interval=5m --timeout=3s CMD curl -f http://localhost/ || exit 1
 
-CMD ["/run.sh"]
+ENTRYPOINT ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,9 @@
 
 VOLUME_HOME="/var/lib/mysql"
 
-if [[ ! -d $VOLUME_HOME/mysql ]]; then
+if [ $no_database == true ]; then
+    echo "=> Using external MySQL server"
+elif [[ ! -d $VOLUME_HOME/mysql ]]; then
     echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"
     echo "=> Installing MySQL ..."
     mysql_install_db > /dev/null 2>&1

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ VOLUME_HOME="/var/lib/mysql"
 
 if [[ "$no_database" != false ]]; then
     echo "=> Using external MySQL server"
-    apachectl -DFOREGROUND
+    apachectl -DFOREGROUND || sleep infinity
 else
     if [[ ! -d $VOLUME_HOME/mysql ]]; then
         echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@ VOLUME_HOME="/var/lib/mysql"
 
 if [[ "$no_database" != false ]]; then
     echo "=> Using external MySQL server"
+    sleep infinity
 else
     if [[ ! -d $VOLUME_HOME/mysql ]]; then
         echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 VOLUME_HOME="/var/lib/mysql"
 
-if [ $no_database == true ]; then
+if [ $no_database != false ]; then
     echo "=> Using external MySQL server"
 elif [[ ! -d $VOLUME_HOME/mysql ]]; then
     echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ VOLUME_HOME="/var/lib/mysql"
 
 if [[ "$no_database" != false ]]; then
     echo "=> Using external MySQL server"
-    sleep infinity
+    apachectl -DFOREGROUND
 else
     if [[ ! -d $VOLUME_HOME/mysql ]]; then
         echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"

--- a/run.sh
+++ b/run.sh
@@ -2,16 +2,18 @@
 
 VOLUME_HOME="/var/lib/mysql"
 
-if [ $no_database != false ]; then
+if [[ "$no_database" != false ]]; then
     echo "=> Using external MySQL server"
-elif [[ ! -d $VOLUME_HOME/mysql ]]; then
-    echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"
-    echo "=> Installing MySQL ..."
-    mysql_install_db > /dev/null 2>&1
-    echo "=> Done!"
-    /create-mysql-admin-user.sh
 else
-    echo "=> Using an existing volume of MySQL"
+    if [[ ! -d $VOLUME_HOME/mysql ]]; then
+        echo "=> An empty or uninitialized MySQL volume is detected in $VOLUME_HOME"
+        echo "=> Installing MySQL ..."
+        mysql_install_db > /dev/null 2>&1
+        echo "=> Done!"
+        /create-mysql-admin-user.sh
+    else
+        echo "=> Using an existing volume of MySQL"
+    fi
+    
+    exec /sbin/my_init
 fi
-
-exec /sbin/my_init


### PR DESCRIPTION
Implemented several options in Dockerfile:
1. HEALTHCHECK - using curl, check every 5 minutes if the webserver is still reachable
2. ENTRYPOINT - instead of CMD to start service
3. ARG NO_DATABASE - can be used to build an image without a local MySQL installation
4. ENV no_database - to store the build-argument from ARG

Changed run.sh to accommodate these changes; don't try to start MySQL if it has not been installed.